### PR TITLE
3.6.2

### DIFF
--- a/acronyms.json
+++ b/acronyms.json
@@ -6320,6 +6320,14 @@
         "description": "Meaning \"What's up?\""
     },
     {
+        "acronym": "TF",
+        "description": "The f*ck"
+    },
+    {
+        "acronym": "LGTM",
+        "description": "Looks good to me"
+    },
+    {
         "acronym": "ZZZZ",
         "description": "Sleeping (or bored)"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "greenmesa",
-    "version": "3.6.1",
+    "version": "3.6.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenmesa",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "A basic multifaceted Discord bot. The dev uses it to practice his coding.",
   "main": "dist/main.js",
   "scripts": {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -462,8 +462,8 @@ client.on("message", async (message: XMessage) => {// This event will run on eve
 
         if (permLevel < pl) {// check if the user has the permissions needed to run the command
             // the access message is a setting for guilds, if disabled members will not be notified of missing permissions
-            const accessMessage = message.guild ? await client.database.getGuildSetting(message.guild, "access_message") : { value: "enabled" };
-            if (accessMessage && accessMessage.value === "enabled") {
+            // const accessMessage = message.guild ? await client.database.getGuildSetting(message.guild, "access_message") : { value: "enabled" };
+            if (!gc || typeof gc.perm_notif === "undefined" || gc.perm_notif) {
                 await message.channel.send("You lack the permissions required to use this command");
             }
             return;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -522,8 +522,12 @@ client.on("message", async (message: XMessage) => {// This event will run on eve
         if (command.permissions && command.permissions.length) {
             const lacking: PermissionString[] = [];
             for (const perm of command.permissions) {// check if a needed permission is not met, injects the embed_links perm if it isn't already specified
-                if (!message.guild?.me?.permissions.has(perm) ||
-                    (message.channel instanceof GuildChannel && !message.channel.permissionsFor(message.guild?.me || "")?.has(Permissions.FLAGS[perm]))) {
+                if (message.channel instanceof GuildChannel &&
+                    (
+                        !message.guild?.me?.permissions.has(perm) ||
+                        !message.channel.permissionsFor(message.guild?.me ?? "")?.has(Permissions.FLAGS[perm])
+                    )
+                ) {
                     lacking.push(perm);
                 }
             }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -613,6 +613,9 @@ client.on("message", async (message: XMessage) => {// This event will run on eve
                             if (flagDef.isNumber && (/* !f.value ||  */!/^(?:[0-9]+(?:\.[0-9]+)?|0x[0-9A-Za-z]{6})$/.test(f.value))) {
                                 throw `You must provide a number value to the flag \`${flagDef.f}\`.`;
                             }
+                            if (flagDef.filter && !flagDef.filter.test(f.value)) {
+                                throw `You passed an invalid value to flag \`${flagDef.f}\`.`;
+                            }
                         }
                     }
                 } catch (error) {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -464,7 +464,7 @@ client.on("message", async (message: XMessage) => {// This event will run on eve
             // the access message is a setting for guilds, if disabled members will not be notified of missing permissions
             // const accessMessage = message.guild ? await client.database.getGuildSetting(message.guild, "access_message") : { value: "enabled" };
             if (!gc || typeof gc.perm_notif === "undefined" || gc.perm_notif) {
-                await message.channel.send("You lack the permissions required to use this command");
+                await message.channel.send("You lack the authority to use this command");
             }
             return;
         }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -70,7 +70,7 @@ export class Commands {
         for (const cmdfile of cmds) {
             const { command } = await import(`${dir}${cmdfile}`);
             if (!command) {
-                console.log(`$ ${this.commandNumber} - \x1b[33mWARNING: \x1b[32mno command contained in this file, it will not work\x1b[0m`);
+                console.log(`$ ${this.commandNumber} - $${cmdfile} \x1b[33mWARNING: \x1b[32mno command contained in this file, it will not work\x1b[0m`);
                 continue;
             }
 

--- a/src/commands/fun/xkcd.ts
+++ b/src/commands/fun/xkcd.ts
@@ -2,7 +2,7 @@ import { permLevels } from '../../permissions';
 import { Command, GuildMessageProps, XClient, XKCDEndpointResponse } from "src/gm";
 import fetch from 'node-fetch';
 import { randomIntFromInterval } from "../../utils/parsers";
-import { CollectorFilter, DMChannel, GuildChannel, MessageAttachment, MessageEmbed, MessageReaction, NewsChannel, TextChannel, User } from "discord.js";
+import { CollectorFilter, DMChannel, MessageAttachment, MessageEmbed, MessageReaction, NewsChannel, TextChannel, User } from "discord.js";
 
 const HOST = "http://xkcd.com/";
 
@@ -13,14 +13,6 @@ async function getComic(number: number): Promise<XKCDEndpointResponse | number> 
     }
     const j: XKCDEndpointResponse = await r.json();
     return j;
-}
-
-function checkFilePerms(c: GuildChannel) {
-    if (!c.isText() || !c.guild.me) return false;
-    if (!c.permissionsFor(c.guild.me)?.has("ATTACH_FILES")) {
-        return false;
-    }
-    return true;
 }
 
 async function sendById(client: XClient, channel: TextChannel | DMChannel | NewsChannel, num: number, wid = "") {
@@ -99,11 +91,10 @@ random
                 });
                 return;
             }
-            await message.channel.startTyping();
+            message.channel.startTyping();
             let ai = 0;
             switch (args[ai].toLowerCase()) {
                 case "latest": {
-                    if (!checkFilePerms(message.channel)) break;
                     ai++;
                     const o = args[ai];
                     if (o) {
@@ -123,7 +114,6 @@ random
                     break;
                 }
                 case "byid": {
-                    if (!checkFilePerms(message.channel)) break;
                     ai++;
                     const o = args[ai];
                     if (!o) {
@@ -143,7 +133,6 @@ random
                     break;
                 }
                 case "random": {
-                    if (!checkFilePerms(message.channel)) break;
                     ai++;
                     const o = args[ai];
                     if (o) {
@@ -153,12 +142,11 @@ random
                     const r = await fetch(`${HOST}/info.0.json`);
                     const j: XKCDEndpointResponse = await r.json();
                     const currentNumber = j.num;
-
+                    
                     await sendById(client, message.channel, randomIntFromInterval(1, currentNumber), message.author.id);
                     break;
                 }
                 case "search": {
-                    if (!checkFilePerms(message.channel)) break;
                     ai++;
                     const o = args.slice(1, args.length).join("+");
                     if (!o) {
@@ -178,7 +166,6 @@ random
                     // ai++;
                     const o = args[ai];
                     if (o && /^[0-9]+$/.test(o)) {
-                        if (!checkFilePerms(message.channel)) break;
                         const pi = parseInt(o, 10);
                         await sendById(client, message.channel, pi, message.author.id);
                         break;

--- a/src/commands/invites/invreset.ts
+++ b/src/commands/invites/invreset.ts
@@ -1,0 +1,41 @@
+import { permLevels } from '../../permissions';
+import { Command, GuildMessageProps } from "src/gm";
+import { stringToMember } from '../../utils/parsers';
+
+export const command: Command<GuildMessageProps> = {
+    name: "invreset",
+    description: {
+        short: "reset all invites data",
+        long: "Reset all stored invites."
+    },
+    usage: "[@member]",
+    cooldown: 15,
+    permLevel: permLevels.member,
+    guildOnly: true,
+    permissions: ["MANAGE_GUILD"],
+    async execute(client, message, args) {
+        try {
+            if (args.length) {
+                const a = args.join(" ");
+                const target = await stringToMember(message.guild, a, true, true, true);
+                if (target) {
+                    const confirm = await client.specials.getUserConfirmation(message.channel, [message.author.id], `Please confirm deletion of invites data for ${target}`);
+                    if (confirm) {
+                        await client.invites.resetInvites(message.guild.id, target.id);
+                    }
+                } else {
+                    await client.specials.sendError(message.channel, `That is an invalid target`);
+                }
+            } else {
+                const confirm = await client.specials.getUserConfirmation(message.channel, [message.author.id], `Please confirm deletion of all invites data`);
+                if (confirm) {
+                    await client.invites.resetInvites(message.guild.id);
+                }
+            }
+        } catch (error) {
+            xlg.error(error);
+            await client.specials.sendError(message.channel);
+            return false;
+        }
+    }
+}

--- a/src/commands/moderation/cwarns.ts
+++ b/src/commands/moderation/cwarns.ts
@@ -1,10 +1,10 @@
-
 import { permLevels } from '../../permissions';
-import { Command } from "src/gm";
+import { Command, GuildMessageProps } from "src/gm";
 import { stringToMember } from "../../utils/parsers";
 
-export const command: Command = {
+export const command: Command<GuildMessageProps> = {
     name: "cwarns",
+    aliases: ["cwarn"],
     description: {
         short: "clear moderator warnings",
         long: "Use to clear the warnings assigned to a user when warned by either the automod or a server moderator."
@@ -12,32 +12,41 @@ export const command: Command = {
     usage: "<member>",
     args: true,
     cooldown: 2,
-    permLevel: permLevels.admin,
+    permLevel: permLevels.mod,
     moderation: true,
     guildOnly: true,
     async execute(client, message, args) {
         try {
-            if (!message.guild) return;
-            const target = await stringToMember(message.guild, args[0], false, false, false);
+            const a = args.join(" ");
+            const target = await stringToMember(message.guild, a, false, false, false);
             if (!target) {
-                await client.specials?.sendError(message.channel, "Invalid target", true);
+                await client.specials.sendError(message.channel, "Invalid target", true);
                 return;
             }
-            const gud = await client.database.getGuildUserData(message.guild.id, target.id);
-            if (!gud || !gud.id) {
-                await client.specials?.sendError(message.channel, "Unable to retrieve user information.", true);
+            const warns = await client.database.getModActionsByUserAndType(target.guild.id, target.id, "warn");
+            // if (!warns) {
+            //     await client.specials.sendError(message.channel, "Unable to retrieve user information.", true);
+            //     return;
+            // }
+            if (!warns) {
+                await client.specials.sendError(message.channel, `${target} (${target.id}) does not have any recorded warnings.`);
                 return;
             }
-            if (!gud.warnings) {
-                await client.specials?.sendError(message.channel, `${target} (${target.id}) does not have any recorded warnings.`);
-                return;
+            client.database.setModAction
+            // const delResult = await client.database.delModActions({
+            //     guildid: target.guild.id,
+            //     userid: target.id,
+            //     type: "warn",
+            // });
+            const editResult = await client.database.massUpdateModActions({ guildid: target.guild.id, userid: target.id, type: "warn" }, { type: "d-warn" });
+            if (editResult && editResult.affectedRows) {
+                await message.channel.send(`Warnings (${editResult.affectedRows}) cleared for ${target}`);
+            } else {
+                await client.specials.sendError(message.channel, `Could not clear warnings`, true);
             }
-            gud.warnings = 0;
-            await client.database.updateGuildUserData(gud);
-            await message.channel.send(`Warnings cleared for ${target}`);
         } catch (error) {
             xlg.error(error);
-            await client.specials?.sendError(message.channel);
+            await client.specials.sendError(message.channel);
             return false;
         }
     }

--- a/src/commands/moderation/nickname.ts
+++ b/src/commands/moderation/nickname.ts
@@ -1,24 +1,20 @@
-
-//import { getGuildSetting } from "../dbmanager";
 import { permLevels, getPermLevel } from "../../permissions";
 import { stringToMember } from "../../utils/parsers";
-import { Command } from "src/gm";
+import { Command, GuildMessageProps } from "src/gm";
 
-export const command: Command = {
+export const command: Command<GuildMessageProps> = {
     name: 'nickname',
     aliases: ['nick'],
-    usage: '[target member],<new nick>',
+    usage: '[target member] <new nick>',
     guildOnly: true,
-    description: 'set a member nickname',
+    description: {
+        short: "set a member nickname",
+        long: "Set the nickname of yourself or another member (if you have the necessary permissions)",
+    },
     args: true,
+    permissions: ["MANAGE_NICKNAMES"],
     async execute(client, message, args) {
         try {
-            if (!message.guild || !message.member) return;
-            /*let moderationEnabled = await getGuildSetting(message.guild, 'all_moderation');
-            if (!moderationEnabled[0] || moderationEnabled[0].value === 'disabled') {
-                return client.specials.sendModerationDisabled(message.channel);
-            }*/
-            
             let target = await stringToMember(message.guild, args[0], true, false, false);
             if (!target || !target.id) {
                 target = message.member;
@@ -29,54 +25,60 @@ export const command: Command = {
                     // now checking for moderation here because this means that someone elses name from the sender is being changed
                     const moderationEnabled = await client.database.getGuildSetting(message.guild, 'all_moderation');
                     if (!moderationEnabled || moderationEnabled.value === 'disabled') {
-                        return client.specials?.sendModerationDisabled(message.channel);
+                        await client.specials.sendModerationDisabled(message.channel);
+                        return;
                     }
                     // confirming that the author has the moderation privileges to use the command
                     const permLevel = await getPermLevel(message.member);
                     if (permLevel < permLevels.mod) {
-                        message.channel.send("Insufficient permissions.").catch(xlg.error);
+                        await message.channel.send("Insufficient permissions.").catch(xlg.error);
                         return;
                     }
                 }
             }
 
             // This is probably an unecessary check but I probably had a reason so I'll keep it
-            if (args[0] === message.member.id) args.shift();
+            // if (args[0] === message.member.id) args.shift();// looking at this later, this should never be true since the target is already parsed earlier
+            // ^ i am keeping this commented here so i will always be able to wonder why the hell i didn't delete this line when rewriting the commana
+            const a = args.join(" ")
 
             // Why would I want it to be changed manually
             //if (target.id == client.id) return message.channel.send('My nickname should be changed manually');
 
+            if (target.id === target.guild.ownerID) {
+                await client.specials.sendError(message.channel, `Because you are the server owner, I will never be able to change your nickname`);
+                return;
+            }
             // I would rather let this error
             //if (!target.manageable) return message.channel.send('I don't have the permissions to manage that target, I am outranked! 🚀 inbound');
 
             // Necessary check to prevent a needless error
             if (args.join(" ").length > 32) {
-                message.channel.send('Nicknames cannot be longer than 32 characters');
+                await message.channel.send('Nicknames cannot be longer than 32 characters');
                 return;
             }
 
             if (args.join(" ") == target?.nickname) {
-                message.channel.send(`\`${args.join(" ")}\` is already the target's nickname`);
+                await message.channel.send(`\`${a}\` is already the target's nickname`);
                 return;
             }
 
             if (args.join(" ").length < 1) {
-                message.channel.send("The new nickname had no length")
+                await message.channel.send("The new nickname had no length")
                 return;
             }
 
             try {
-                await target?.setNickname(args.join(" "), 'adjustment thru nick command');
-                await message.channel.send(`\\✅ Changed the nickname of \`${target.user.tag}\` to \`${target.nickname}\``)
+                await target.setNickname(args.join(" "), 'adjustment thru nick command');
+                await message.channel.send(`\\✅ Changed the nickname of \`${target.user.tag}\` to \`${target.displayName}\``)
             } catch (e) {
                 xlg.log(e.message);
-                await client.specials?.sendError(message.channel, `◍ Command Error:\n${e.message}`)
+                await client.specials.sendError(message.channel, `◍ Command Error:\n${e.message}`)
             }
         } catch (error) {
             xlg.error(error);
-            await client.specials?.sendError(message.channel);
+            await client.specials.sendError(message.channel);
             return false;
         }
     }
 }
-

--- a/src/commands/moderation/nickname.ts
+++ b/src/commands/moderation/nickname.ts
@@ -58,7 +58,7 @@ export const command: Command<GuildMessageProps> = {
                 return;
             }
 
-            if (args.join(" ") == target?.nickname) {
+            if (args.join(" ") == target.nickname) {
                 await message.channel.send(`\`${a}\` is already the target's nickname`);
                 return;
             }

--- a/src/commands/moderation/purge.ts
+++ b/src/commands/moderation/purge.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { Command, GuildMessageProps } from 'src/gm';
 import { permLevels } from '../../permissions';
 import { stringToMember } from '../../utils/parsers';
+import { argsMustBeNum } from '../../utils/specials';
 
 export const command: Command<GuildMessageProps> = {
     name: "purge",
@@ -13,18 +14,28 @@ export const command: Command<GuildMessageProps> = {
     aliases: ['clear'],
     usage: "<# of messages to delete> [@target]",
     args: true,
+    flags: [
+        {
+            f: "r",
+            d: "show receipt"
+        }
+    ],
     guildOnly: true,
     permLevel: permLevels.mod,
     moderation: true,
-    async execute(client, message, args) {
+    async execute(client, message, args, flags) {
         try {
+            if (!(await argsMustBeNum(message.channel, [args[0]]))) {// check to make sure first argument is a number (any number)
+                return;
+            }
             const deleteCount = parseInt(args[0], 10); // get the delete count, as an actual number.
             args.shift();
-            const target = await stringToMember(message.guild, args.join(" "));
+            const a = args.join(" ");
+            const target = await stringToMember(message.guild, a);
 
             // Ooooh nice, combined conditions. <3
             if (!deleteCount || deleteCount < 2) {
-                await client.specials?.sendError(message.channel, "Provide a number (2-100) for the number of messages to delete.");
+                await client.specials.sendError(message.channel, "Provide a number (2-100) for the number of messages to delete.");
                 return;
             }
 
@@ -41,7 +52,7 @@ export const command: Command<GuildMessageProps> = {
 
             // Get messages and delete them. Simple enough, right?
             const messages = await message.channel.messages.fetch(opts);
-            let c = 0;
+            let c = 0;// the number of messages to be deleted (after they are fetched and filtered)
             if (target) {
                 if (target.user.lastMessage?.channel.id === message.channel.id) {
                     messages.set(target.user.lastMessage.id, target.user.lastMessage);
@@ -68,12 +79,12 @@ export const command: Command<GuildMessageProps> = {
                 await message.channel.bulkDelete(mc);
             }
 
-            if (args.join(" ").endsWith("-m")) {
+            if (flags.find(x => x.name === "r")) {// if receipt flag is provided, send deletion receipt
                 await message.channel.send(`Purged ${c} messages`);// People don't seem to like that it says a message at the end.
             }
         } catch (error) {
             xlg.error(error);
-            await client.specials?.sendError(message.channel);
+            await client.specials.sendError(message.channel);
             return false;
         }
     }

--- a/src/commands/moderation/rmrole.ts
+++ b/src/commands/moderation/rmrole.ts
@@ -4,35 +4,104 @@ import { Command, GuildMessageProps } from "src/gm";
 
 export const command: Command<GuildMessageProps> = {
     name: "rmrole",
-    description: "remove a role",
+    description: {
+        short: "remove a role or cleanup roles",
+        long: "Remove individual roles or mass delete roles using flag filters.",
+    },
     usage: "<@role>",
-    args: true,
+    args: false,
+    flags: [
+        {
+            f: "e",
+            d: "delete empty roles",
+        },
+        {
+            f: "pop",
+            d: "remove roles with <= n members",
+            v: "1000",
+            isNumber: true,
+        },
+        {
+            f: "x",
+            d: "roles to exclude from filter deletion",
+            v: "123456789012345678,812345678901234567",
+            notEmpty: true,
+            filter: /^[0-9]{18}(,[0-9]{18})*$/,
+        },
+    ],
     permLevel: permLevels.admin,
     guildOnly: true,
     moderation: true,
-    async execute(client, message, args) {
+    permissions: ["MANAGE_ROLES"],
+    async execute(client, message, args, flags) {
         try {
-            const target = stringToRole(message.guild, args.join(" "), true, true);
-            if (!target) {
-                await client.specials?.sendError(message.channel, "That role could not be found.")
-                return;
-            }
-            if (target.name === "@everyone" && target.position === 0) {
-                await client.specials?.sendError(message.channel, "@everyone is not a normal role and cannot be deleted");
-                return;
-            }
-            await target.delete();
-            await message.channel.send({
-                embed: {
-                    color: await client.database.getColor("success"),
-                    description: `Role removed successfully`
+            if (flags.length) {
+                const exclusionFlag = flags.find(x => x.name === "x");
+                const exclude = exclusionFlag && exclusionFlag.value ? exclusionFlag.value.split(",") : [];
+                const modeFlag = flags[0];
+                let c = 0;
+                if (modeFlag.name === "e") {
+                    const rolesToDelete = message.guild.roles.cache.filter(r => !r.members.size && !exclude.includes(r.id));
+                    for (const [, role] of rolesToDelete) {
+                        try {
+                            if (!role.deleted && role.editable) {
+                                await role.delete();
+                                c++;
+                            }
+                        } catch (error) {
+                            //
+                        }
+                    }
+                } else if (modeFlag.name === "pop") {
+                    if (modeFlag.numberValue > -1) {
+                        const rolesToDelete = message.guild.roles.cache.filter(r => r.members.size <= modeFlag.numberValue && !exclude.includes(r.id));
+                        for (const [, role] of rolesToDelete) {
+                            try {
+                                if (!role.deleted && role.editable) {
+                                    await role.delete();
+                                    c++;
+                                }
+                            } catch (error) {
+                                //
+                            }
+                        }
+                    } else {
+                        await message.channel.send(` `);
+                    }
+                } else {
+                    await message.channel.send(`\`${modeFlag.name.escapeDiscord()}\` is no known flag`);
+                    return;
                 }
-            });
+                if (c) {
+                    await message.channel.send(`${c} roles were deleted`);
+                } else {
+                    await message.channel.send(`No roles were deleted.`);
+                }
+            } else if (args.length) {
+                const a = args.join(" ");
+                const target = stringToRole(message.guild, a, true, true);
+                if (!target) {
+                    await client.specials.sendError(message.channel, "That role could not be found.");
+                    return;
+                }
+                if (target.name === "@everyone" && target.position === 0) {
+                    await client.specials.sendError(message.channel, "@everyone is not a normal role and cannot be deleted");
+                    return;
+                }
+                await target.delete();
+                await message.channel.send({
+                    embed: {
+                        color: await client.database.getColor("success"),
+                        description: `Role \`${target.name.escapeDiscord()}\` removed successfully`
+                    }
+                });
+            } else {
+                await client.specials.sendError(message.channel, `Arguments or flags are required for this command`);
+            }
         } catch (error) {
             xlg.error(error);
-            await client.specials?.sendError(message.channel, "Failure removing role");
+            await client.specials.sendError(message.channel, "Failure removing role");
             return false;
         }
     }
 }
-

--- a/src/commands/moderation/unmute.ts
+++ b/src/commands/moderation/unmute.ts
@@ -55,7 +55,7 @@ export const command: Command<GuildMessageProps> = {
             await toMute.roles.remove(mutedRole, `unmuted by ${message.author.tag}`);
             if (toMute.voice.connection && toMute.voice.mute) toMute.voice.setMute(false).catch(console.error);
 
-            Contraventions.logUnmute(toMute, message.member);
+            await Contraventions.logUnmute(toMute, message.member);
 
             message.channel.send(`\\✅ Unmuted ${toMute.user.tag}`).catch(console.error);
         } catch (error) {

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -19,20 +19,20 @@ export const command: Command<GuildMessageProps> = {
         try {
             const target = await stringToMember(message.guild, args[0], false, false, false);
             if (!target) {
-                await client.specials?.sendError(message.channel, "Invalid target", true);
+                await client.specials.sendError(message.channel, "Invalid target", true);
                 return;
             }
             args.shift();
             const reason = args.join(" ");
             const warnResult = await warn(client, target, message.member, reason);
             if (warnResult) {
-                await message.channel.send(`\\✅ \`${target.user.tag.escapeDiscord()}\` has been warned`);
+                await message.channel.send(`\\✅ \`${target.user.tag.escapeDiscord()}\` has been warned${target.id === message.author.id ? `\nBe happy that you got to yourself before someone else did` : ""}`);
                 return;
             }
-            message.channel.send(`It seems that something may have gone wrong`);
+            await message.channel.send(`It seems that something may have gone wrong`);
         } catch (error) {
             xlg.error(error);
-            await client.specials?.sendError(message.channel);
+            await client.specials.sendError(message.channel);
             return false;
         }
     }

--- a/src/commands/say.ts
+++ b/src/commands/say.ts
@@ -11,12 +11,14 @@ function constructMessage(content: string, flags: CommandArgumentFlag[], atts: C
     }
     if (flags.length) {
         for (const flag of flags) {
-            if (!fin.embed) fin.embed = new MessageEmbed();
-            fin.embed.setDescription("");
+            if (!fin.embed) {
+                fin.embed = new MessageEmbed();
+                fin.embed.setDescription("");
+            }
             if ((flag.name === "description" || flag.name === "desc") && flag.value) {
                 fin.embed.setDescription(flag.value);
             }
-            if ((flag.name === "color" || flag.name === "clr") && flag.value) {
+            if ((flag.name === "color" || flag.name === "colour" || flag.name === "clr") && flag.value) {
                 if (parseInt(flag.value, 10) && parseInt(flag.value, 10) <= 16777215) {
                     fin.embed.setColor(parseInt(flag.value, 10));
                 } else {

--- a/src/commands/utility/superscript.ts
+++ b/src/commands/utility/superscript.ts
@@ -1,33 +1,64 @@
-
 import { permLevels } from '../../permissions';
 import { Command } from "src/gm";
-//const { getGlobalSetting } = require("../dbmanager");
+
+/**
+ *                       |  A 	B 	C 	D 	E 	F 	G 	H 	I 	J 	K 	L 	M 	N 	O 	P 	Q 	R 	S 	T 	U 	V 	W 	X 	Y 	Z
+ * Superscript capital 	 |  ᴬ 	ᴮ 	* 	ᴰ 	ᴱ 	* 	ᴳ 	ᴴ 	ᴵ 	ᴶ 	ᴷ 	ᴸ 	ᴹ 	ᴺ 	ᴼ 	ᴾ 	* 	ᴿ 		ᵀ 	ᵁ 	ⱽ 	ᵂ
+ * Superscript small cap |  	* 					* 	* 	ᶦ 			ᶫ 		ᶰ 				* 			ᶸ 				*
+ * Superscript minuscule |  ᵃ 	ᵇ 	ᶜ 	ᵈ 	ᵉ 	ᶠ 	ᵍ 	ʰ 	ⁱ 	ʲ 	ᵏ 	ˡ 	ᵐ 	ⁿ 	ᵒ 	ᵖ 	* 	ʳ 	ˢ 	ᵗ 	ᵘ 	ᵛ 	ʷ 	ˣ 	ʸ 	ᶻ
+ */
+
 const superConversion = {
     "a": "ᵃ",
+    "A": "ᴬ",
     "b": "ᵇ",
+    "B": "ᴮ",
     "c": "ᶜ",
-    "d": "ᵈ",
+    "C": "ᶜ",
+    "d": "ᴰ",
+    "D": "ᵈ",
     "e": "ᵉ",
+    "E": "ᴱ",
     "f": "ᶠ",
+    "F": "ᶠ",
     "g": "ᵍ",
+    "G": "ᴳ",
     "h": "ʰ",
-    "i": "ᶦ",
+    "H": "ᴴ",
+    "i": "ⁱ",
+    "I": "ᴵ",
     "j": "ʲ",
+    "J": "ʲ",
     "k": "ᵏ",
+    "K": "ᴷ",
     "l": "ˡ",
+    "L": "ᴸ",
     "m": "ᵐ",
+    "M": "ᴹ",
     "n": "ⁿ",
+    "N": "ᴺ",
     "o": "ᵒ",
+    "O": "ᴼ",
     "p": "ᵖ",
+    "P": "ᴾ",
     "q": "ᑫ",
+    "Q": "ᑫ",
     "r": "ʳ",
+    "R": "ᴿ",
     "s": "ˢ",
+    "S": "ˢ",
     "t": "ᵗ",
+    "T": "ᵀ",
     "u": "ᵘ",
+    "U": "ᵁ",
     "v": "ᵛ",
+    "V": "ⱽ",
     "w": "ʷ",
-    "x": "ˣ",
+    "W": "ᵂ",
     "y": "ʸ",
+    "Y": "ʸ",
+    "x": "ˣ",
+    "X": "ˣ",
     "z": "ᶻ",
     "1": "¹",
     "2": "²",
@@ -41,19 +72,20 @@ const superConversion = {
     "0": "⁰",
     ",": "\u22C5",
     ".": "\u22C5",
+    "?": "ˀ",
+    "!": "ᶥ",
 }
 
 export const command: Command = {
     name: "superscript",
     aliases: ["super"],
     description: {
-        short: "convert text to superscript",
+        short: "text to superscript",
         long: "Send text and convert all compatible letters to superscript."
     },
     usage: "<text>",
     args: true,
     permLevel: permLevels.member,
-    guildOnly: false,
     async execute(client, message, args) {
         try {
             const text = args.join(" ").split("");
@@ -65,16 +97,15 @@ export const command: Command = {
             }
             
             if (text.length < 1) {
-                client.specials?.sendError(message.channel, "the conversion resulted in no text to display");
+                await client.specials.sendError(message.channel, "the conversion resulted in no text to display");
                 return;
             }
 
-            message.channel.send(text.join(""));
+            await message.channel.send(text.join(""));
         } catch (error) {
             xlg.error(error);
-            await client.specials?.sendError(message.channel);
+            await client.specials.sendError(message.channel);
             return false;
         }
     }
 }
-

--- a/src/commands/utility/userinfo.ts
+++ b/src/commands/utility/userinfo.ts
@@ -125,7 +125,7 @@ export const command: Command<GuildMessageProps> = {
                         },
                         {
                             name: "Designation",
-                            value: `${permLevelName}\n[Wʰᵃᵗ ᶦˢ ᵗʰᶦˢ?](https://enigmadigm.com/status/Designation/A%20property%20the%20bot%20gives%20you/It%20is%20used%20when%20checking%20for%20required%20or%20missing%20permissions)`,// How the bot internally sees the member in terms of permissions
+                            value: `${permLevelName}\n[ᵂʰᵃᵗ ⁱˢ ᵗʰⁱˢˀ](https://enigmadigm.com/status/Designation/A%20property%20the%20bot%20gives%20you/It%20is%20used%20when%20checking%20for%20required%20or%20missing%20permissions)`,// How the bot internally sees the member in terms of permissions
                             inline: true,
                         },
                         {

--- a/src/dbmanager.ts
+++ b/src/dbmanager.ts
@@ -152,6 +152,9 @@ export class DBManager {
         if (name === "embed") {
             return 0x2F3136;
         }
+        if (name === "normal") {
+            return 0x202225;
+        }
         if (!name.endsWith("_embed_color")) {
             name += "_embed_color";
         }
@@ -1402,7 +1405,7 @@ export class DBManager {
         try {
             const queryOptions = <(keyof ModActionEditData<"guildid">)[]>Object.keys(query);
             if (!queryOptions.length) return false;
-            let sql = `DELETE FROM invitetracking WHERE`;
+            let sql = `DELETE FROM modactions WHERE`;
             for (let i = 0; i < queryOptions.length; i++) {
                 const opt = queryOptions[i];
                 const val = query[opt];
@@ -1430,6 +1433,47 @@ export class DBManager {
             xlg.error(error);
             return false;
         }
+    }
+
+    /**
+     * Update a user's data. This is global data (opposed to guild data).
+     */
+    async massUpdateModActions(query: Partial<ModActionEditData>, values: Partial<ModActionEditData>): Promise<InsertionResult | false> {
+        const updateValues = <(keyof ModActionEditData)[]>Object.keys(values);
+        if (!updateValues.length) return false;
+        let sql = `UPDATE modactions SET`;
+        for (let i = 0; i < updateValues.length; i++) {
+            const opt = updateValues[i];
+            const val = values[opt];
+            sql += `${i === 0 ? "" : ","} \`${opt}\` = ${escape(val)}`;
+        }
+        sql += ` WHERE `;
+        const queryOptions = <(keyof ModActionEditData)[]>Object.keys(query);
+        if (!queryOptions.length) return false;
+        for (let i = 0; i < queryOptions.length; i++) {
+            const opt = queryOptions[i];
+            const val = query[opt];
+            sql += `${i === 0 ? "" : " AND"} \`${opt}\` = ${escape(val)}`;
+        }
+        console.log(sql)
+        const result = await <Promise<InsertionResult>>this.query(sql);
+        if (!result || !result.affectedRows) {
+            return false;
+        }
+        return result;
+        // const { guildid, userid, casenumber, superid } = query;// get provided data to log
+        // if (!guildid || !userid) return false;
+        // const e = await this.getModActionByGuildCase(guildid, casenumber) || await this.getModActionBySuperId(superid ?? "");// see if there is a preexisting case with sid or casenumber
+
+        // let sql = ``;
+        // if (e && e.casenumber === casenumber) {// if a preexisting case was found, edit it
+        //     sql = `DELETE FROM modactions WHERE guildid = ${escape(guildid)} AND casenumber = ${escape(casenumber)}`;
+        // }
+        // const result = await <Promise<InsertionResult>>this.query(sql);
+        // if (!result || !result.affectedRows) {
+        //     return false;
+        // }
+        // return result;
     }
 
     /**

--- a/src/dbmanager.ts
+++ b/src/dbmanager.ts
@@ -114,7 +114,7 @@ export class DBManager {
             this.query("CREATE TABLE IF NOT EXISTS `userdata` ( `userid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `createdat` timestamp NOT NULL DEFAULT current_timestamp(), `updatedat` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), `bio` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `afk` text COLLATE utf8mb4_unicode_ci DEFAULT NULL, `offenses` int(11) DEFAULT 0, `nicknames` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `bans` int(11) DEFAULT 0, PRIMARY KEY (`userid`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
             this.query("CREATE TABLE IF NOT EXISTS `guilduserdata` ( `id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL, `userid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `guildid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `createdat` timestamp NOT NULL DEFAULT current_timestamp(), `updatedat` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), `offenses` int(11) NOT NULL DEFAULT 0, `warnings` int(11) NOT NULL DEFAULT 0, `bans` int(11) NOT NULL DEFAULT 0, `bio` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `nicknames` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `roles` text COLLATE utf8mb4_unicode_ci DEFAULT NULL, `banned` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'false', `modnote` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT '', PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
             //this.query("CREATE TABLE IF NOT EXISTS `modactions` ( `id` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL, `guildid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `type` tinytext COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'log', `data` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
-            this.query("CREATE TABLE IF NOT EXISTS `modactions` ( `id` int(11) NOT NULL AUTO_INCREMENT, `superid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `guildid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `casenumber` int(11) NOT NULL DEFAULT 0, `userid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `usertag` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `type` tinytext COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'log', `created` timestamp NOT NULL DEFAULT current_timestamp(), `updated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), `endtime` text COLLATE utf8mb4_unicode_ci DEFAULT NULL, `agent` text COLLATE utf8mb4_unicode_ci NOT NULL, `agenttag` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `summary` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', PRIMARY KEY (`id`), UNIQUE KEY `superid` (`superid`)) ENGINE=InnoDB AUTO_INCREMENT=56 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+            this.query("CREATE TABLE IF NOT EXISTS `modactions` ( `id` int(11) NOT NULL AUTO_INCREMENT, `superid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `guildid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `casenumber` int(11) NOT NULL DEFAULT 0, `userid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `usertag` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `type` tinytext COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'log', `created` timestamp NOT NULL DEFAULT current_timestamp(), `updated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), `endtime` text COLLATE utf8mb4_unicode_ci DEFAULT NULL, `agent` text COLLATE utf8mb4_unicode_ci NOT NULL, `agenttag` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `summary` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `notified` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`id`), UNIQUE KEY `superid` (`superid`)) ENGINE=InnoDB AUTO_INCREMENT=90 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
             //async function dbInit() {}
             this.query("CREATE TABLE IF NOT EXISTS `cmdhistory` ( `invocation_id` int(11) NOT NULL AUTO_INCREMENT, `command_name` text COLLATE utf8mb4_unicode_ci NOT NULL, `message_content` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `guildid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `userid` varchar(18) COLLATE utf8mb4_unicode_ci DEFAULT NULL, `messageid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `channelid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `invocation_time` timestamp NOT NULL DEFAULT current_timestamp(), PRIMARY KEY (`invocation_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
             this.query("CREATE TABLE IF NOT EXISTS `invitetracking` ( `id` int(11) NOT NULL AUTO_INCREMENT, `guildid` varchar(18) COLLATE utf8mb4_unicode_ci NOT NULL, `inviteat` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(), `invitee` text COLLATE utf8mb4_unicode_ci NOT NULL, `inviteename` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '', `inviter` text COLLATE utf8mb4_unicode_ci NOT NULL, `invitername` text COLLATE utf8mb4_unicode_ci NOT NULL, `code` text COLLATE utf8mb4_unicode_ci NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
@@ -1678,6 +1678,24 @@ export class DBManager {
                 return result;
             }
             return false;
+        } catch (error) {
+            xlg.error(error);
+            return false;
+        }
+    }
+
+    async deleteInvites(query: Partial<InvitedUserData>): Promise<InsertionResult | false> {
+        try {
+            const queryOptions = <(keyof Partial<InvitedUserData>)[]>Object.keys(query);
+            if (!queryOptions.length) return false;
+            let sql = `DELETE FROM invitetracking WHERE`;
+            for (let i = 0; i < queryOptions.length; i++) {
+                const opt = queryOptions[i];
+                const val = query[opt];
+                sql += `${i === 0 ? "" : " AND"} \`${opt}\` = ${escape(val)}`;
+            }
+            const result = await <Promise<InsertionResult>>this.query(`${sql}`);
+            return result;
         } catch (error) {
             xlg.error(error);
             return false;

--- a/src/gm.d.ts
+++ b/src/gm.d.ts
@@ -631,6 +631,10 @@ export interface ModActionData {
      * The given reason/case summary for the incident
      */
     summary: string;
+    /**
+     * A boolean representing whether or not the user was notified of the action taken against them, if necessary
+     */
+    notified: number;
 }
 
 export type ModActionEditData<R = 'guildid' | 'agent' | 'userid'> = Required<Pick<ModActionData, R>> & Partial<Omit<ModActionData, R>>;

--- a/src/gm.d.ts
+++ b/src/gm.d.ts
@@ -935,7 +935,7 @@ export interface CmdHistoryRow {
     invocation_time: string;
 }
 
-export interface InvitedData {// data for the people that have joined and were tracked by an invite
+export interface InvitedUserData {// data for the people that have joined and were tracked by an invite
     id: number;
     guildid: Snowflake;
     inviteat: string;
@@ -958,6 +958,7 @@ export interface InviteStateData {
     guildid: Snowflake;
     invites: InviteData[];
     rewards?: Record<number, InviteLevelReward>;
+    reset_at?: string;
 }
 
 export interface InviteLevelReward {

--- a/src/gm.d.ts
+++ b/src/gm.d.ts
@@ -469,6 +469,13 @@ export interface GuildUserDataRow {
     modnote?: string;
 }
 
+export interface HomeEndpointData {
+    guild: {
+        id: string;
+        name: string;
+    };
+}
+
 export interface AutomoduleEndpointData extends GuildsEndpointBase {
     automodule: AutomoduleData;
 }
@@ -859,6 +866,10 @@ export interface CommandsGlobalConf {
      * Send that the command is disabled in chat
      */
     respond?: boolean;
+    /**
+     * notify the user if they don't have the internal permissions to run the command
+     */
+    perm_notif?: boolean;
 }
 
 export interface CommandConf {

--- a/src/gm.d.ts
+++ b/src/gm.d.ts
@@ -283,14 +283,41 @@ export interface CmdTrackingRow {
 
 export interface TwitchHookRow {
     id: string;
+    /**
+     * The channel ID of the streamer
+     */
     streamerid: string;
+    /**
+     * The ID of the guild to which this sub belongs
+     */
     guildid: Snowflake;
+    /**
+     * The ID of the channel in which notifications should be sent
+     */
     channelid: Snowflake;
+    /**
+     * The UID of the streamer
+     */
     streamerlogin: string;
+    /**
+     * The message to be sent in a notification
+     */
     message: string;
+    /**
+     * The date at which this stream will expire
+     */
     expires: string;
+    /**
+     * The configured number of streams the sub should be deleted after
+     */
     delafter: number;
+    /**
+     * Number of notifications received
+     */
     notified: number;
+    /**
+     * The date of the last notification received (not necessarily successfully sent)
+     */
     laststream: string;
 }
 

--- a/src/gm.d.ts
+++ b/src/gm.d.ts
@@ -122,8 +122,19 @@ export interface CommandFlagDefinition {
      */
     v?: string;
     // aliases?: string[];
+    /**
+     * Specify if the value must be a number, the command will not be executed if a number value is not provided
+     */
     isNumber?: boolean;
+    /**
+     * Specify if the flag cannot be sent without a value, the command will not be executed if a value is not provided
+     */
     notEmpty?: boolean;
+    /**
+     * A custom filter to validate input
+     * If the filter does not match input, the command will not be executed, and a generic "invalid value" error will be displayed
+     */
+    filter?: RegExp;
 }
 
 export interface CommandArgumentFlag {

--- a/src/struct/Invites.ts
+++ b/src/struct/Invites.ts
@@ -1,6 +1,6 @@
-import { Guild, GuildMember, Permissions, User } from "discord.js";
+import { Guild, GuildMember, Permissions, Snowflake, User } from "discord.js";
 import moment from "moment";
-import { InviteData, InviteStateData, XClient } from "../gm";
+import { InsertionResult, InviteData, InviteStateData, XClient } from "../gm";
 import { isSnowflake } from "../utils/specials";
 
 /**
@@ -18,9 +18,8 @@ export default class {
     public async getFull(guild: Guild): Promise<{ invitesNow: InviteData[], invitesBefore: InviteData[], increased: InviteData[], decreased: InviteData[] } | void> {
         try {
             if (!guild.me?.permissions.has(Permissions.FLAGS.MANAGE_GUILD)) return;
-            const previousResult = await this.client.database.getGuildSetting(guild.id, "invites_data");//TODO: make this a direct method for interacting with the db table
-            const stateBefore: InviteStateData = previousResult ? JSON.parse(previousResult.value) : { guildid: guild.id, invites: [] };
-            const invitesBefore = stateBefore.invites;
+            const dataState = await this.getInvitesState(guild.id);
+            const invitesBefore = dataState.invites;
             const invitesCollection = await guild.fetchInvites();
             const invites: InviteData[] = invitesCollection.filter(x => typeof x.uses === "number" && x.inviter instanceof User).map((x) => {
                 return { inviter: x.inviter?.id || "", uses: x.uses || 0, code: x.code, channel: x.channel.id, members: x.memberCount || 0 };
@@ -34,7 +33,7 @@ export default class {
                 return (preexisting && x.members < preexisting.members);
             })
             const newState: InviteStateData = { guildid: guild.id, invites };
-            await this.client.database.editGuildSetting(guild, "invites_data", JSON.stringify(newState).escapeSpecialChars());// make sure the new invites state gets updated in the database
+            await this.updateInvitesState(newState);// make sure the new invites state gets updated in the database
             return { invitesBefore, invitesNow: invites, increased: increasedInvites, decreased: decreasedInvites };
         } catch (error) {
             xlg.error(error);
@@ -102,6 +101,37 @@ export default class {
             //TODO: here the invite entry in the db could be updated to reflect the departure of the user
         } catch (error) {
             xlg.error(error);
+        }
+    }
+
+    public async getInvitesState(gid: Snowflake): Promise<InviteStateData> {
+        const r = await this.client.database.getGuildSetting(gid, "invites_data");
+        const dataState: InviteStateData = r ? JSON.parse(r.value) : { guildid: gid, invites: [] };
+        return dataState;
+    }
+
+    public async updateInvitesState(dataState: InviteStateData): Promise<InsertionResult> {
+        const r = await this.client.database.editGuildSetting(dataState.guildid, "invites_data", JSON.stringify(dataState).escapeSpecialChars());
+        return r;
+    }
+
+    public async resetInvites(gid: Snowflake, mid?: Snowflake): Promise<void> {
+        if (mid) {
+            const r2 = await this.client.database.deleteInvites({
+                guildid: gid,
+                inviter: mid
+            });
+            console.log("del4m", r2);
+            
+        } else {
+            const r = await this.client.database.editGuildSetting(gid, "invites_data", undefined, true);
+            console.log("delall", r);
+            
+            const r2 = await this.client.database.deleteInvites({
+                guildid: gid,
+            });
+            console.log("delev", r2);
+            
         }
     }
 }

--- a/src/utils/contraventions.ts
+++ b/src/utils/contraventions.ts
@@ -166,6 +166,8 @@ export class Contraventions {//TODO: get rid of this class and just export all o
                 color = await Bot.client.database.getColor("success");
             } else if (action === "warn") {
                 color = await Bot.client.database.getColor("warn");
+            } else if (action.match(/^(?:d-|h-).*$/)) {
+                color = await Bot.client.database.getColor("normal");// #202225
             } else {
                 color = await Bot.client.database.getColor("info");
             }
@@ -173,7 +175,7 @@ export class Contraventions {//TODO: get rid of this class and just export all o
         const e = {
             color,
             timestamp: new Date(),
-            title: `Case ${casenum} ● ${titleCase(action)} ● ${targTag.escapeDiscord()}`,// 💼
+            title: `Case ${casenum} ● ${titleCase(action, /[- ]/)} ● ${targTag.escapeDiscord()}`,// 💼
             description: `**Perpetrator:** ${targTag.escapeDiscord()} ${targUser}\n**Marshal:** ${modTag.escapeDiscord()} ${mod instanceof User ? mod : null}`,
             footer: {
                 text: `User: ${targId} Mod: ${modId}`

--- a/src/utils/modactions.ts
+++ b/src/utils/modactions.ts
@@ -227,7 +227,7 @@ export async function mute(client: XClient, target: GuildMember, time = 0, mod: 
         noNotify = true;
     }
 
-    await Contraventions.logMute(target, time, mod, `${reason}${noNotify ? " - could not notify offender" : ""}`, remute);
+    await Contraventions.logMute(target, time, mod, `${reason}`, remute, noNotify ? true : false);
 
     if (time) {
         /*setTimeout(async () => {
@@ -303,7 +303,7 @@ export async function ban(client: XClient, target: GuildMember, time = 0, mod: G
         reason: `Requested by ${modtag}${summary ? ` for ${summary}` : ``}`
     });
 
-    await Contraventions.logBan(target, mod, `${summary ? summary : ``}${noNotify ? " - could not notify offender" : ""}`, time);
+    await Contraventions.logBan(target, mod, `${summary ? summary : ``}`, time, noNotify ? true : false);
 
     if (time) {
         const data: UnbanAction["data"] = {
@@ -372,7 +372,7 @@ export async function kick(client: XClient, target: GuildMember, mod: GuildMembe
     }
 
     await target.kick(`Requested by ${modtag}${summary ? ` for ${summary}` : ``}`);
-    await Contraventions.logKick(target, mod, `${summary ? summary : ``}${noNotify ? " - could not notify offender" : ""}`);
+    await Contraventions.logKick(target, mod, `${summary ? summary : ``}`, noNotify ? true : false);
     return `\\✅ Kicked ${target.user.tag}`;
 }
 
@@ -407,7 +407,7 @@ export async function warn(client: XClient, target: GuildMember, mod: GuildMembe
         noNotify = true;
     }
 
-    await Contraventions.logWarn(target, mod, `${summary ? summary : ``}${noNotify ? " - could not notify offender" : ""}`);
+    await Contraventions.logWarn(target, mod, `${summary ? summary : ``}`, noNotify ? true : false);
 
     checkWarnings(client, target);
 

--- a/src/utils/specials.ts
+++ b/src/utils/specials.ts
@@ -1,54 +1,38 @@
 import moment from 'moment';
 import { ClientValuesGuild, DashboardMessage, SkeletonGuildObject, XClient } from '../gm';
-import { Channel, MessageEmbed, MessageEmbedOptions, Snowflake, TextChannel } from 'discord.js';
+import { Channel, CollectorFilter, DMChannel, Message, MessageActionRow, MessageButton, MessageComponentInteraction, MessageEmbed, MessageEmbedOptions, NewsChannel, Snowflake, TextChannel } from 'discord.js';
 import { Bot } from "../bot";
 import Client from '../struct/Client';
 import { combineEmbedText } from './parsers';
 
 export async function sendModerationDisabled(channel: Channel): Promise<void> {
-    try {
-        if (!channel.isText() || !('guild' in channel)) return;
-        const fail_embed_color = await Bot.client.database.getColor("fail");
-        channel.send({
-            embed: {
-                color: fail_embed_color,
-                description: `Server moderation in ${channel.guild.name.escapeDiscord()} is currently disabled. Admins must enable moderation features with \`settings moderation enable\`.`
-            }
-        });
-    } catch (error) {
-        xlg.error(error);
-    }
+    if (!channel.isText() || !('guild' in channel)) return;
+    const fail_embed_color = await Bot.client.database.getColor("fail");
+    await channel.send({
+        embed: {
+            color: fail_embed_color,
+            description: `Server moderation in ${channel.guild.name.escapeDiscord()} is currently disabled. Admins must enable moderation features with \`settings moderation enable\`.`
+        }
+    });
 }
 
-export async function sendError(channel: Channel, message?: string, errorTitle: string | boolean = false): Promise<void> {
-    try {
-        if (!channel.isText()) return;
-        await channel.send({
-            embed: {
-                color: await Bot.client.database.getColor("fail") || 16711680,
-                title: errorTitle ? typeof errorTitle === "string" ? errorTitle : "Error" : undefined,
-                description: (message && message.length) ? message : "Something went wrong. ¯\\_(ツ)_/¯"
-            }
-        });
-        return;
-    } catch (error) {
-        xlg.error(error);
-    }
+export async function sendError(channel: TextChannel | DMChannel | NewsChannel, message?: string, errorTitle: string | boolean = false): Promise<Message> {
+    return await channel.send({
+        embed: {
+            color: await Bot.client.database.getColor("fail") || 16711680,
+            title: errorTitle ? typeof errorTitle === "string" ? errorTitle : "Error" : undefined,
+            description: (message && message.length) ? message : "Something went wrong. ¯\\_(ツ)_/¯"
+        }
+    });
 }
 
-export async function sendInfo(channel: Channel, message: string): Promise<void> {
-    try {
-        if (!channel.isText()) return;
-        channel.send({
-            embed: {
-                color: 0x337fd5/* await Bot.client.database.getColor("info") */,
-                description: `<:sminfo:818342088088354866> ${message}`
-            }
-        });
-        return;
-    } catch (error) {
-        xlg.error(error);
-    }
+export async function sendInfo(channel: TextChannel | DMChannel | NewsChannel, message: string): Promise<Message> {
+    return await channel.send({
+        embed: {
+            color: 0x337fd5/* await Bot.client.database.getColor("info") */,
+            description: `<:sminfo:818342088088354866> ${message}`
+        }
+    });
 }
 
 export async function argsNumRequire(channel: Channel, args: string[], num: number): Promise<boolean> {
@@ -106,7 +90,30 @@ export async function argsMustBeNum(channel: Channel, args: string[]): Promise<b
     }
 }
 
-export function timedMessagesHandler(client: XClient): void {
+export async function getUserConfirmation(channel: TextChannel | DMChannel | NewsChannel, acceptFrom: Snowflake[], text = "Please confirm"): Promise<boolean> {
+    const cm = await channel.send({
+        embed: {
+            color: 0x337fd5/* await Bot.client.database.getColor("info") */,
+            description: `<:sminfo:818342088088354866> ${text}`
+        },
+        components: [new MessageActionRow().addComponents(new MessageButton({ customID: "yes", label: "Yes", style: "SUCCESS" }), new MessageButton({ customID: "no", label: "No", style: "DANGER" }))],
+    });
+    const pushFilter: CollectorFilter<[MessageComponentInteraction]> = (inter) => acceptFrom.includes(inter.user.id);
+    const pushes = await cm.awaitMessageComponentInteractions(pushFilter, { max: 1, time: 10 * 1000 });
+    const buttonOption = pushes.first();
+    if (!buttonOption) {
+        await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`No confirmation`).setColor(await Bot.client.database.getColor("fail")), components: [] });
+        return false;
+    }
+    if (buttonOption.customID === "yes") {
+        await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`Confirmed`).setColor(await Bot.client.database.getColor("success")), components: [] });
+        return true;
+    }
+    await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`Aborted`).setColor(await Bot.client.database.getColor("fail")), components: [] });
+    return false;
+}
+
+export function timedMessagesHandler(client: XClient): void {//TODO: make this a real handler, integrate with cronjobs or timedactions or something
     setInterval(async () => {
         if (moment().utcOffset(-5).format('M/D HH:mm') == "9/26 21:30") {
             const pcr = await client.database.getGlobalSetting('primchan');

--- a/src/utils/specials.ts
+++ b/src/utils/specials.ts
@@ -90,7 +90,7 @@ export async function argsMustBeNum(channel: Channel, args: string[]): Promise<b
     }
 }
 
-export async function getUserConfirmation(channel: TextChannel | DMChannel | NewsChannel, acceptFrom: Snowflake[], text = "Please confirm"): Promise<boolean> {
+export async function getUserConfirmation(channel: TextChannel | DMChannel | NewsChannel, acceptFrom: Snowflake[], text = "Please confirm", confirmationMessage = "**Confirmed**", rejectionMessage = "**Aborted**"): Promise<boolean> {
     const cm = await channel.send({
         embed: {
             color: 0x337fd5/* await Bot.client.database.getColor("info") */,
@@ -102,14 +102,14 @@ export async function getUserConfirmation(channel: TextChannel | DMChannel | New
     const pushes = await cm.awaitMessageComponentInteractions(pushFilter, { max: 1, time: 10 * 1000 });
     const buttonOption = pushes.first();
     if (!buttonOption) {
-        await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`No confirmation`).setColor(await Bot.client.database.getColor("fail")), components: [] });
+        await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`**No confirmation**`).setColor(await Bot.client.database.getColor("fail")), components: [] });
         return false;
     }
     if (buttonOption.customID === "yes") {
-        await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`Confirmed`).setColor(await Bot.client.database.getColor("success")), components: [] });
+        await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(confirmationMessage).setColor(await Bot.client.database.getColor("success")), components: [] });
         return true;
     }
-    await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(`Aborted`).setColor(await Bot.client.database.getColor("fail")), components: [] });
+    await cm.edit({ embed: new MessageEmbed(cm.embeds[0]).setDescription(rejectionMessage).setColor(await Bot.client.database.getColor("fail")), components: [] });
     return false;
 }
 

--- a/src/utils/zalgo.ts
+++ b/src/utils/zalgo.ts
@@ -130,13 +130,13 @@ export const Z = {
         return len ? Math.floor(Math.random() * len + 1) - 1 : Math.random();
     },
     generate(str: string): string {
-        const str_arr = str.split(''),
-            output = str_arr.map(function (a) {
-                if (a == " ") return a;
-                for (let i = 0, l = Z.random(16); i < l; i++) {
-                    const rand = <0 | 1 | 2>Z.random(3);
-                    a += Z.chars[rand][
-                        Z.random(Z.chars[rand].length)
+        const str_arr = str.split(''),// convert conversion text into character array
+            output = str_arr.map(function (a) {// remap this array into zalgo
+                if (a == " ") return a;// if the character is a space, return it
+                for (let i = 0, l = Z.random(16); i < l; i++) {// for a random number of iterations (up to 16)
+                    const rand = <0 | 1 | 2>Z.random(3);// a number from 0-2, represents which position to append
+                    a += Z.chars[rand][// append these random characters to the given character
+                        Z.random(Z.chars[rand].length)// select a random character from the character position (3 positions, up to the number of characters in that position)
                     ];
                 }
                 return a;

--- a/src/website/client/src/components/DashboardAutomod/AutomoduleCard.tsx
+++ b/src/website/client/src/components/DashboardAutomod/AutomoduleCard.tsx
@@ -297,7 +297,7 @@ export function AutomoduleCard(props: CustomModuleCardProps) {
             <div className="x-card-body">
                 {(!mod.punishment && (!mod.actions || !mod.actions.length)) && checkEnabled(mod) ? (
                     <div className="inline-error">
-                        A punishment and action is not set for this module. It will do nothing.
+                        Neither punishment nor action is set for this module. It will do nothing.
                     </div>
                 ) : null}
                 {wmessage ? (

--- a/src/website/client/src/components/DashboardCommands/index.tsx
+++ b/src/website/client/src/components/DashboardCommands/index.tsx
@@ -20,21 +20,27 @@ interface CmdCat {
     // show: boolean;
 }
 
-interface PatchRequest {
-    apply: string[];
-    enabled: boolean;
-    delete_overwrites?: boolean;
-    channel_mode?: boolean;
-    channels?: string[];
-    role_mode?: boolean;
-    roles?: string[];
-    description_edited?: string;
-    cooldown?: number;
-    exp_level?: number;
-    level?: number;
-    overwites_ignore?: string[];
-    respond?: boolean;
-}
+type PatchRequest = Omit<Partial<CommandConf & CommandsGlobalConf & {
+    delete_overwrites?: boolean,
+    apply: string[],
+    enabed: boolean
+}>, 'description' | 'description_short' | 'category' | 'confined' | 'overwrite' | 'name'>;
+
+// interface PatchRequest {
+//     apply: string[];
+//     enabled: boolean;
+//     delete_overwrites?: boolean;
+//     channel_mode?: boolean;
+//     channels?: string[];
+//     role_mode?: boolean;
+//     roles?: string[];
+//     description_edited?: string;
+//     cooldown?: number;
+//     exp_level?: number;
+//     level?: number;
+//     overwites_ignore?: string[];
+//     respond?: boolean;
+// }
 
 const DISABLED = <FontAwesomeIcon icon={faSkull} />;
 const WARNING = <FontAwesomeIcon icon={faExclamationTriangle} />;
@@ -67,7 +73,7 @@ export function DashboardCommands(props: HomeProps) {
     const [selectedCmds, setSelectedCmds] = React.useState<string[]>([]);// the commands that should be shown as selected on the dashboard
     const [selectedCats, setSelectedCats] = React.useState<string[]>([]);// the cats that should be shown as selected on the dashboard
     const [applying, setApplying] = React.useState<string[]>([]);// the commands that the settings will actually be applied to on the dashboard
-    const [pending, setPending] = React.useState<CommandConf & CommandsGlobalConf>({name: "", enabled: true, channel_mode: false, role_mode: false, channels: [], roles: [], default_cooldown: 0,overwrite: false});// the settings to apply to the 'applying' commands on the next patch, should be cleared after every patch or cancellation
+    const [pending, setPending] = React.useState<CommandConf & CommandsGlobalConf>({ name: "", enabled: true, channel_mode: false, role_mode: false, channels: [], roles: [], default_cooldown: 0, overwrite: false });// the settings to apply to the 'applying' commands on the next patch, should be cleared after every patch or cancellation
     // const [delOw, setDelOw] = React.useState(false);// whether the applied commands should be deleted as overwrites on the next patch
     const [searchFor, setSearchFor] = React.useState("");// the search string to be used in sorting, deactivated by default
     const [em, setEm] = React.useState("");// the error message to show in the overwrite conf modal
@@ -173,6 +179,7 @@ export function DashboardCommands(props: HomeProps) {
                 role_mode: pending.role_mode,
                 roles: pending.roles,
                 respond: pending.respond,
+                perm_notif: pending.perm_notif
             }
         }
         const obj = {
@@ -380,6 +387,16 @@ export function DashboardCommands(props: HomeProps) {
         patchNow(2);
     }
 
+    const togglePermNotif = () => {
+        const n = typeof globalConf.perm_notif === "boolean" && !globalConf.perm_notif ? true : false;
+        pending.perm_notif = n;
+        setPending({
+            ...pending,
+            perm_notif: n
+        });
+        patchNow(2);
+    }
+
     const handleSave = () => {
         setWaiting(true);
         if (mm === 2) {
@@ -483,7 +500,8 @@ export function DashboardCommands(props: HomeProps) {
                                     <button onClick={showIconKey}>Icon Key</button>
                                     <button disabled>Set Global Defaults</button>
                                     <button onClick={editModRole}>Set Mod Role</button>
-                                    <button onClick={toggleRespond}>{typeof globalConf.respond === "boolean" && !globalConf.respond ? UNCHECKED : CHECKED} Send Disabled Message</button>
+                                    <button onClick={toggleRespond} title="Send a message to notify users that the command is disabled">{typeof globalConf.respond === "boolean" && !globalConf.respond ? UNCHECKED : CHECKED} Disabled Message</button>
+                                    <button onClick={togglePermNotif} title="Send a message to notify users that they don't have permission to use a command">{typeof globalConf.perm_notif === "boolean" && !globalConf.perm_notif ? UNCHECKED : CHECKED} Missing Perms Message</button>
                                 </div>
                                 <hr style={{ marginBottom: 10, marginTop: 0 }} />
                                 <div className="c-cats">

--- a/src/website/client/src/components/DashboardHome/index.tsx
+++ b/src/website/client/src/components/DashboardHome/index.tsx
@@ -57,36 +57,6 @@ export function DashboardHome(props: HomeProps) {
         prefix: yup.string().required()
     });
 
-    const handleAccessMessageClicked = (e: React.ChangeEvent<HTMLInputElement>) => {
-        let am = false;
-        if (e.target.checked) {
-            am = true;
-        }
-        const hdrs = new Headers();
-        hdrs.append("Content-Type", "application/x-www-form-urlencoded");
-        const fd = new URLSearchParams();
-        fd.append("permnotif", `${am}`);
-        const obj = {
-            method: 'PUT',
-            headers: hdrs,
-            body: fd
-        };
-        try {
-            fetch(`/api/discord/guilds/${props.meta.id}/permnotif`, obj)
-                .then(x => x.json())
-                .then((d: { guild: { id: string, permNotif: string } }) => {
-                    if (d.guild && d.guild.permNotif === `${am}`) {
-                        setStatus({ msg: "Saved.", success: true });
-                    } else {
-                        setStatus({ msg: "Failed to save.", success: false });
-                    }
-                })
-        } catch (error) {
-            console.error(error);
-            setStatus({ msg: "Failed to save.", success: false });
-        }
-    }
-
     return loaded ? (
         <div style={{ width: "100%", padding: "0 15px", marginLeft: "auto", marginRight: "auto" }}>
             <br />

--- a/src/website/client/src/components/DashboardHome/index.tsx
+++ b/src/website/client/src/components/DashboardHome/index.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import { /*Input, Button, Container*/ Switch, FormControl, FormLabel, Center, Spinner } from '@chakra-ui/react';
+import { Switch, FormControl, FormLabel, Center, Spinner } from '@chakra-ui/react';
 import { Formik, ErrorMessage } from "formik";
 import { HomeProps } from '../../pages/DashboardPage';
 import * as yup from 'yup';
+import { HomeEndpointData } from '../../../../../gm';
 
-/*function ModSwitch(event: React.ChangeEvent<HTMLInputElement>) {
-    console.log(event)
-}*/
-
-export function DashboardHome(props: HomeProps/* {match}: RouteComponentProps<MatchParams> */) {
-    const [permNotif, setPermNotif] = React.useState<boolean>(false)
+export function DashboardHome(props: HomeProps) {
     const [moderation, setModeration] = React.useState(props.meta.moderation || false);
     const firstMod = React.useRef(true);
     const { setStatus } = props;
@@ -18,9 +14,7 @@ export function DashboardHome(props: HomeProps/* {match}: RouteComponentProps<Ma
     React.useEffect(() => {
         fetch(`/api/discord/guilds/${props.meta.id}/home`)
             .then(x => x.json())
-            .then(d => {
-                //console.log(d)
-                setPermNotif(d.home.permNotif);
+            .then((d: HomeEndpointData) => {
                 setLoaded(true);
             })
             .catch(e => {
@@ -64,7 +58,6 @@ export function DashboardHome(props: HomeProps/* {match}: RouteComponentProps<Ma
     });
 
     const handleAccessMessageClicked = (e: React.ChangeEvent<HTMLInputElement>) => {
-        console.log(e);
         let am = false;
         if (e.target.checked) {
             am = true;
@@ -123,7 +116,7 @@ export function DashboardHome(props: HomeProps/* {match}: RouteComponentProps<Ma
                                 </FormLabel>
                                 <Switch id="enable-moderation-all" onChange={(e) => setModeration(e.target.checked)} defaultChecked={props.meta.moderation} />
                             </FormControl>
-                            <hr style={{ marginTop: 10, marginBottom: 15 }} />
+                            {/* <hr style={{ marginTop: 10, marginBottom: 15 }} />
                             <h4 className="cardsubtitle">No Perms Access Message</h4>
                             <p style={{ marginBottom: "1rem" }}>Toggle the option to notify users that they don't have the required permissions when they use an elevated command.</p>
                             <FormControl display="flex" alignItems="center">
@@ -131,7 +124,7 @@ export function DashboardHome(props: HomeProps/* {match}: RouteComponentProps<Ma
                                         Enable Access Message
                                 </FormLabel>
                                 <Switch id="enable-permnotif" onChange={handleAccessMessageClicked} defaultChecked={permNotif} />
-                            </FormControl>
+                            </FormControl> */}
                             {/*status && status.module === "moderation" && (
                                 <>
                                     <br />

--- a/src/website/routes/twitch.ts
+++ b/src/website/routes/twitch.ts
@@ -204,12 +204,11 @@ export function twitchRouter(client: XClient): Router {
                                             //channel.send(`${sub.message || `${req.body.data[0].user_name} just went live!`}\nhttps://twitch.tv/${req.body.data[0].user_name}`)
                                             if (sub.delafter > -1 && sub.delafter <= sub.notified) {
                                                 Bot.client.database.removeTwitchSubscription(sub.streamerid, sub.guildid);
-                                            } else {
-                                                Bot.client.database.incrementTwitchNotified(sub.guildid, req.body.data[0].started_at);
                                             }
                                         }
                                     }
                                 }
+                                await Bot.client.database.incrementTwitchNotified(req.query.streamer, req.body.data[0].started_at);
                             }
                         }
                     } else {

--- a/src/website/static/index.html
+++ b/src/website/static/index.html
@@ -138,7 +138,7 @@
             <div class="card statistic" style="width: 18rem;">
                 <div class="card-body">
                     <p style="font-weight: bold !important;font-size: 20px !important;"><i class="fal fa-users"></i></p>
-                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">120+</p>
+                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">120k+</p>
                     <p style="font-weight: bold !important;font-size: 20px !important;">users</p>
                 </div>
             </div>

--- a/src/website/static/index.html
+++ b/src/website/static/index.html
@@ -96,20 +96,32 @@
             </div>
             <div class="card">
                 <div class="card-body">
-                    <h5 class="card-title"><i class="fas fa-computer-classic"></i> Management</h5>
-                    <p class="card-text">Stratum is incredibly modular. Use its advanced settings to customize it to your server's needs! Customizing options include the admin staples like enabling and disabling commands to control what goes on in your server. The bot also has existing and future moderation features like server-logging, case-logging, moderation commands, and more. To access the more common options, use the <code>settings</code> command. It can be used to turn on features like level role rewards, logging, and much more.</p>
+                    <h5 class="card-title"><i class="fas fa-computer-classic"></i> Advanced Management</h5>
+                    <p class="card-text">Stratum is incredibly modular. Use its advanced settings to customize it to your server's needs! Customizing options include the admin staples like enabling and disabling commands to control what goes on in your server. The bot also has features like server-logging, case-logging, moderation commands, and more. To access the more common options, use the <code>settings</code> command. It can be used to turn on features like level role rewards, logging, and much more.</p>
                 </div>
             </div>
             <div class="card">
                 <div class="card-body">
-                    <h5 class="card-title"><i class="fas fa-dice-d12"></i> Games/Fun</h5>
+                    <h5 class="card-title"><i class="fas fa-dice-d12"></i> Fun Commands</h5>
                     <p class="card-text">Stratum is always gaining new fun commands and game features. Spice up your server with many fun and entertaining commands with jokes, trivia, would you rather, image generation, and more. And there is not just games, don't miss the many random commands that the bot has.</p>
                 </div>
             </div>
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title"><i class="fab fa-twitch"></i> Twitch Notifications</h5>
-                    <p class="card-text">Twitch notifying is another great feature of the bot. Use it to remind yourself or your server (you can use it to ping members) that a certain streamer is live. Just provide the name of your streamer, the channel, and a customized message if you want to the <code>addtwitch</code> command.</p>
+                    <p class="card-text">Twitch notifying is a well used feature. Use it to notify of Twitch streams, combined with a custom message. Let your server know that your favorite streamers are live. Just provide the name of your streamer, the channel, and a customized message if you want. Use the <code>addtwitch</code> command or its own dashboard page.</p>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title"><i class="fad fa-portal-enter"></i> Invite Tracking</h5>
+                    <p class="card-text">Wondering who is inviting members to your server? Want to run competitions to see who can invite the most members? Want to provide incentives to invite people using role rewards? The bot provides advanced invite tracking to help you accomplish all of this. Just send: <code>sm help invites</code>.</p>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title"><i class="fad fa-star-christmas"></i> Starboard</h5>
+                    <p class="card-text">A well tested feature supporting the classic starboard. When users react to any message with enough stars, post an entry in the starboard channel, giving that message extra attention.</p>
                 </div>
             </div>
         </div>

--- a/src/website/static/index.html
+++ b/src/website/static/index.html
@@ -119,21 +119,21 @@
             <div class="card statistic" style="width: 18rem;">
                 <div class="card-body">
                     <p style="font-weight: bold !important;font-size: 20px !important;"><i class="fal fa-server"></i></p>
-                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">90+</p>
+                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">140+</p>
                     <p style="font-weight: bold !important;font-size: 20px !important;">servers</p>
                 </div>
             </div>
             <div class="card statistic" style="width: 18rem;">
                 <div class="card-body">
                     <p style="font-weight: bold !important;font-size: 20px !important;"><i class="fal fa-users"></i></p>
-                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">90K+</p>
+                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">120+</p>
                     <p style="font-weight: bold !important;font-size: 20px !important;">users</p>
                 </div>
             </div>
             <div class="card statistic" style="width: 18rem;">
                 <div class="card-body">
                     <p style="font-weight: bold !important;font-size: 20px !important;"><i class="fal fa-cogs"></i></p>
-                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">100+</p>
+                    <p class="card-title" style="font-size: 50px !important;line-height: 15px !important;letter-spacing: -0.06em !important;font-weight: bold !important;">120+</p>
                     <p style="font-weight: bold !important;font-size: 20px !important;">commands</p>
                 </div>
             </div>


### PR DESCRIPTION
```diff
+ move permissions notif to dashboard/commands tab
+ updated the home page
- fixed bug with `say`'s embed feature
+ modlog changed to have the "unable to notify" remark as an actual config property and unobtrusive emoji
+ added `invreset`, reset users' invite stats
+ backend structure and running changes
+ flag `r` added to `purge`, allowing you to see deletion receipt if you want
- fixed big bug with twitch streams' notification count that I failed to notice
+ `role` was partially rewritten, again
+ updated `acronyms`
+ `nickname` was refactored to be more friendly when it doesn't work like you want
+ rewrote `rmrole` and added flags allowing you to mass delete roles; for example, empty roles
- fixed xkcd infinite typing and no response bug
+ `cwarns` was repaired to actually work
+ fix `superscript`
- fixed `starboard` emoji bug
+ released partial `starboard` button support
```